### PR TITLE
Support environment-provided connection string

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -12,9 +12,20 @@ builder.Services.AddRazorPages(options =>
 });
 
 // Add MySQL DbContext and Identity
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+if (string.IsNullOrWhiteSpace(connectionString))
+{
+    connectionString = Environment.GetEnvironmentVariable("CONNECTIONSTRINGS__DEFAULTCONNECTION");
+}
+
+if (string.IsNullOrWhiteSpace(connectionString))
+{
+    throw new InvalidOperationException("Connection string 'DefaultConnection' is not configured.");
+}
+
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseMySql(
-        builder.Configuration.GetConnectionString("DefaultConnection"),
+        connectionString,
         new MySqlServerVersion(new Version(8, 0, 0))
     )
 );


### PR DESCRIPTION
## Summary
- read connection string from `CONNECTIONSTRINGS__DEFAULTCONNECTION` when configuration is empty
- fail fast if no connection string is provided

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a940d986dc832dbf6e852128fd7f72