### PR TITLE
fix: use correct secret for connection string

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,10 +38,10 @@ jobs:
       - name: Set connection string (machine scope)
         shell: powershell
         env:
-          CONN: ${{ secrets.ConnectionStrings__DefaultConnection }}
+          CONN: ${{ secrets.CONNECTIONSTRINGS__DEFAULTCONNECTION }}
         run: |
-          if (-not $env:CONN) { throw "GitHub secret ConnectionStrings__DefaultConnection is missing." }
-          setx ConnectionStrings__DefaultConnection "$env:CONN" /M
+          if (-not $env:CONN) { throw "GitHub secret CONNECTIONSTRINGS__DEFAULTCONNECTION is missing." }
+          setx CONNECTIONSTRINGS__DEFAULTCONNECTION "$env:CONN" /M
           # Optional: set environment name
           setx ASPNETCORE_ENVIRONMENT "Production" /M
 


### PR DESCRIPTION
## Summary
- correct connection string secret reference in deploy workflow

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 errors when accessing package repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1e5a5ddc832d88c9c247d6e4b01a